### PR TITLE
Support for setting keyring backend properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.0.2 - 2024-03-17 - What type is that thingy in the window
 
 * Handle type conversion/passing more robustly
+* Support for setting backend properties/options.
 
 ## v0.0.1 - 2024-03-11 - It's a secret
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ secret_handlers:
     # The keyring backend to use (optional.) If omitted keyrings built-in
     # process will apply
     backend: keyring.backends.null.Keyring
+    # Any other key and value pairs will be assigned to attributes on the
+    # backend once it's been created. (optional)
+    some_backend_property: 42
 
 providers:
   route53:

--- a/octodns_keyring/__init__.py
+++ b/octodns_keyring/__init__.py
@@ -22,9 +22,12 @@ class KeyringSecretsBackendException(KeyringSecretsException):
 
 
 class KeyringSecrets(BaseSecrets):
-    def __init__(self, name, backend=None):
+    def __init__(self, name, backend=None, **kwargs):
         super().__init__(name)
         self.backend = self._load_backend(backend)
+
+        for k, v in kwargs.items():
+            setattr(self.backend, k, v)
 
     def _load_backend(self, backend):
         if backend is None:

--- a/tests/test_provider_octodns_keyring.py
+++ b/tests/test_provider_octodns_keyring.py
@@ -81,3 +81,10 @@ class TestKeyringSecrets(TestCase):
         val = ks.fetch('octodns/ignored', None)
         self.assertEqual((42,), val)
         self.assertIsInstance(val, tuple)
+
+    def test_params(self):
+        filename = '/find/it/here'
+        ks = KeyringSecrets(
+            'test', backend='helpers.DummyBackend', filename=filename
+        )
+        self.assertEqual(filename, ks.backend.filename)


### PR DESCRIPTION
As far as I can tell keyring backend options are set as properties on the backend. E.g. https://pypi.org/project/keyrings.cryptfile/

```python
from getpass import getpass
from os import getenv
from keyrings.cryptfile.cryptfile import CryptFileKeyring
kr = CryptFileKeyring()
kr.keyring_key = getenv("KEYRING_CRYPTFILE_PASSWORD") or getpass()
keyring.set_keyring(kr)
```

So this PR adds support for that pattern by setting properties on the backend for any extra params passed into the secrets handler.