### PR TITLE
Add octodns-keyring helper tool, support secret set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.3 - 2024-??-?? - ???
+
+* octodns-keyring tool added to enable secret management
+* KeyringSecrets.set method added, used by ^
+
 ## v0.0.2 - 2024-03-17 - What type is that thingy in the window
 
 * Handle type conversion/passing more robustly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.0.3 - 2024-??-?? - ???
 
 * octodns-keyring tool added to enable secret management
-* KeyringSecrets.set method added, used by ^
+* KeyringSecrets.set & delete methods added, used by ^
 
 ## v0.0.2 - 2024-03-17 - What type is that thingy in the window
 

--- a/octodns_keyring/__init__.py
+++ b/octodns_keyring/__init__.py
@@ -58,12 +58,15 @@ class KeyringSecrets(BaseSecrets):
 
         return klass()
 
+    def _parse_name(self, name):
+        return name.split('/')
+
     def set(self, name, value):
-        service_name, secret_name = name.split('/')
+        service_name, secret_name = self._parse_name(name)
         self.backend.set_password(service_name, secret_name, value)
 
     def fetch(self, name, source):
-        service_name, secret_name = name.split('/')
+        service_name, secret_name = self._parse_name(name)
         val = self.backend.get_password(service_name, secret_name)
         if val is None:
             raise KeyringSecretsException(f'failed to find {name}')
@@ -79,3 +82,7 @@ class KeyringSecrets(BaseSecrets):
                 # didn't work, leave it as-is, a string
                 pass
         return val
+
+    def delete(self, name):
+        service_name, secret_name = self._parse_name(name)
+        self.backend.delete_password(service_name, secret_name)

--- a/octodns_keyring/__init__.py
+++ b/octodns_keyring/__init__.py
@@ -58,6 +58,10 @@ class KeyringSecrets(BaseSecrets):
 
         return klass()
 
+    def set(self, name, value):
+        service_name, secret_name = name.split('/')
+        self.backend.set_password(service_name, secret_name, value)
+
     def fetch(self, name, source):
         service_name, secret_name = name.split('/')
         val = self.backend.get_password(service_name, secret_name)

--- a/octodns_keyring/cmds/__init__.py
+++ b/octodns_keyring/cmds/__init__.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+'''
+Octo-DNS keyring tool
+'''
+
+from argparse import ArgumentParser
+from getpass import getpass
+
+from octodns_keyring import KeyringSecrets
+
+
+def main():
+    parser = ArgumentParser(description=__doc__.split('\n')[1])
+
+    parser.add_argument(
+        '--backend',
+        required=False,
+        help='The keyring backend to use (optional.) If omitted keyrings built-in process will apply',
+    )
+    parser.add_argument(
+        '--backend-args',
+        nargs='*',
+        required=False,
+        help='Backend configation, attributes to be assign on the backend once created. Format key1=val1 key2=val. "--" will end ... args',
+    )
+    parser.add_argument(
+        '--fetch',
+        action='store_true',
+        default=False,
+        required=False,
+        help='Fetch and print the existing values',
+    )
+    parser.add_argument(
+        'names',
+        nargs='*',
+        help='Values to set in the keyring backend. Format service_name/secret_name, e.g. octodns/ns1_api_key. Multiple secrets are space seperated. User will be prompted for the value of each',
+    )
+
+    args = parser.parse_args()
+
+    kwargs = {}
+    for backend_arg in args.backend_args or []:
+        k, v = backend_arg.split('=')
+        kwargs[k] = v
+
+    ks = KeyringSecrets('octodns-keyring', args.backend, **kwargs)
+
+    for name in args.names:
+        if args.fetch:
+            value = ks.fetch(name, None)
+            print(f'{name}={value}')
+        else:
+            value = getpass(f'{name}: ')
+            ks.set(name, value)
+
+
+if __name__ == '__main__':
+    main()

--- a/octodns_keyring/cmds/__init__.py
+++ b/octodns_keyring/cmds/__init__.py
@@ -31,6 +31,13 @@ def main():
         help='Fetch and print the existing values',
     )
     parser.add_argument(
+        '--delete',
+        action='store_true',
+        default=False,
+        required=False,
+        help='Delete existing secrets',
+    )
+    parser.add_argument(
         'names',
         nargs='*',
         help='Values to set in the keyring backend. Format service_name/secret_name, e.g. octodns/ns1_api_key. Multiple secrets are space seperated. User will be prompted for the value of each',
@@ -49,6 +56,9 @@ def main():
         if args.fetch:
             value = ks.fetch(name, None)
             print(f'{name}={value}')
+        elif args.delete:
+            ks.delete(name)
+            print(f'{name} *deleted*')
         else:
             value = getpass(f'{name}: ')
             ks.set(name, value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ line-length=80
 skip-string-normalization=true
 skip-magic-trailing-comma=true
 
+[tool.coverage.run]
+omit=["octodns_keyring/cmds/*"]
+
 [tool.isort]
 profile = "black"
 known_first_party="octodns_keyring"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author='Ross McFarland',
     author_email='rwmcfa1@gmail.com',
     entry_points={
-        'console_scripts': {'octodns-keyring': 'octodns_keyring.cmds:main'}
+        'console_scripts': {'octodns-keyring = octodns_keyring.cmds:main'}
     },
     description=description,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ tests_require = ('pytest', 'pytest-cov', 'pytest-network')
 setup(
     author='Ross McFarland',
     author_email='rwmcfa1@gmail.com',
+    entry_points={
+        'console_scripts': {'octodns-keyring': 'octodns_keyring.cmds:main'}
+    },
     description=description,
     extras_require={
         'dev': tests_require

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -59,3 +59,22 @@ class TupleBackend(KeyringBackend):
 
     def get_password(self, servicename, username):
         return (42,)
+
+
+class DictBackend(KeyringBackend):
+    '''Always returns a tuple with the answer to everything'''
+
+    priority = 1
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.data = {}
+
+    def set_password(self, servicename, username, password):
+        self.data[f'{servicename}/{username}'] = password
+
+    def delete_password(self, servicename, username):
+        self.data[f'{servicename}/{username}'].pop()
+
+    def get_password(self, servicename, username):
+        return self.data.get(f'{servicename}/{username}')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -74,7 +74,7 @@ class DictBackend(KeyringBackend):
         self.data[f'{servicename}/{username}'] = password
 
     def delete_password(self, servicename, username):
-        self.data[f'{servicename}/{username}'].pop()
+        self.data.pop(f'{servicename}/{username}')
 
     def get_password(self, servicename, username):
         return self.data.get(f'{servicename}/{username}')

--- a/tests/test_provider_octodns_keyring.py
+++ b/tests/test_provider_octodns_keyring.py
@@ -98,3 +98,7 @@ class TestKeyringSecrets(TestCase):
         value = 'Hello World!'
         ks.set('octodns/key', value)
         self.assertEqual(value, ks.fetch('octodns/key', None))
+
+        ks.delete('octodns/key')
+        with self.assertRaises(KeyringSecretsException):
+            ks.fetch('octodns/key', None)

--- a/tests/test_provider_octodns_keyring.py
+++ b/tests/test_provider_octodns_keyring.py
@@ -88,3 +88,13 @@ class TestKeyringSecrets(TestCase):
             'test', backend='helpers.DummyBackend', filename=filename
         )
         self.assertEqual(filename, ks.backend.filename)
+
+    def test_set(self):
+        ks = KeyringSecrets('test', backend='helpers.DictBackend')
+
+        with self.assertRaises(KeyringSecretsException):
+            ks.fetch('octodns/key', None)
+
+        value = 'Hello World!'
+        ks.set('octodns/key', value)
+        self.assertEqual(value, ks.fetch('octodns/key', None))


### PR DESCRIPTION
```console
$ octodns-keyring -h
usage: octodns-keyring [-h] [--backend BACKEND] [--backend-args [BACKEND_ARGS ...]] [--fetch] [names ...]

Octo-DNS keyring tool

positional arguments:
  names                 Values to set in the keyring backend. Format service_name/secret_name, e.g. octodns/ns1_api_key. Multiple secrets are space seperated. User will be prompted for the value of each

options:
  -h, --help            show this help message and exit
  --backend BACKEND     The keyring backend to use (optional.) If omitted keyrings built-in process will apply
  --backend-args [BACKEND_ARGS ...]
                        Backend configation, attributes to be assign on the backend once created. Format key1=val1 key2=val. "--" will end ... args
  --fetch               Fetch and print the existing values
  --delete              Delete existing secrets
```


```console
# getpass is used to safely grab the secret from the terminal, e.g. pasted in
$ octodns-keyring octodns/ns1_api_key octodns/route53_access_key_id octodns/route53_secret_access_key
octodns/ns1_api_key:
octodns/route53_access_key_id:
octodns/route53_secret_access_key:
# stored values can be retrieved
$ octodns-keyring --fetch octodns/ns1_api_key octodns/route53_access_key_id octodns/route53_secret_access_key
octodns/ns1_api_key=It's a secret
octodns/route53_access_key_id=this one isn't that sensitive
octodns/route53_secret_access_key=this one is for sure
```