### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.3 - 2024-??-?? - ???
+## v1.0.0 - 2025-05-04 - 1.0
 
 * octodns-keyring tool added to enable secret management
 * KeyringSecrets.set & delete methods added, used by ^

--- a/octodns_keyring/__init__.py
+++ b/octodns_keyring/__init__.py
@@ -10,7 +10,7 @@ from octodns.secret.base import BaseSecrets
 from octodns.secret.exception import SecretsException
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.2'
+__version__ = __VERSION__ = '1.0.0'
 
 
 class KeyringSecretsException(SecretsException):


### PR DESCRIPTION
## v1.0.0 - 2025-05-04 - 1.0

* octodns-keyring tool added to enable secret management
* KeyringSecrets.set & delete methods added, used by ^
* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x